### PR TITLE
Bug fix for partial timeout when tab synch occurs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,9 @@ interval, maintaining the users session while s/he is using your application for
 ## Changes
 
 * Added an onSuccess callback
-* Changed the keepAliveUrl to return json.
+* Changed the keepAliveUrl to return json
+* Exposed many of the private timer methods
+* Now checks your server session to find out when the last in-browser activity was; good if your users open multiple tabs.
 
 Example Setup:
 
@@ -33,7 +35,3 @@ Example Setup:
 			// Do whatever with response
 		}
 	});
-
-Example PHP Response:
-
-	return json_encode(array('msg' => 'OK'));

--- a/keepalive.php
+++ b/keepalive.php
@@ -1,1 +1,15 @@
-OK
+<?php
+    session_start();
+    $incomingVal = $_GET['lastActive'];
+    $sessionVal = $_SESSION['lastActive'];
+    if($incomingVal > $sessionVal) {
+        $_SESSION['lastActive'] = $incomingVal;
+        $returnVal = $incomingVal;
+    }
+    else {
+        $returnVal = $sessionVal;
+    }
+?>{
+    "msg": "OK",
+    "lastActive": "<?php echo $returnVal; ?>"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "jquery-idle-timeout",
+  "version": "1.2.1",
+  "description": "See the original [Mint.com example](http://www.erichynds.com/examples/jquery-idle-timeout/example-mint.htm), or a [demo](http://www.erichynds.com/examples/jquery-idle-timeout/example-dialog.htm) using jQuery UI's dialog widget.",
+  "main": "./src/idletimeout",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/FireEngineRed/jquery-idle-timeout.git"
+  },
+  "author": "",
+  "license": "(MIT OR GPL)",
+  "bugs": {
+    "url": "https://github.com/FireEngineRed/jquery-idle-timeout/issues"
+  },
+  "homepage": "https://github.com/FireEngineRed/jquery-idle-timeout#readme"
+}

--- a/src/jquery.idletimeout.js
+++ b/src/jquery.idletimeout.js
@@ -116,7 +116,8 @@
 
 			$.ajax({
 				timeout: options.AJAXTimeout,
-				url: options.keepAliveURL + '?lastActive=' + $(document).idleTimer('getTimes')['start'],
+				url: options.keepAliveURL + '?lastActive=' + $(document).idleTimer('getTimes')['start']
+										  + '&page=' + encodeURIComponent(window.location.pathname),
 				dataType: "json",
 				error: function(){
 					self.failedRequests--;

--- a/src/jquery.idletimeout.js
+++ b/src/jquery.idletimeout.js
@@ -14,7 +14,7 @@
  *
  */
 
-(function($, win){
+module.exports = (function($, win){
 
 	var idleTimeout = {
 		init: function( element, resume, options ){

--- a/src/jquery.idletimeout.js
+++ b/src/jquery.idletimeout.js
@@ -158,11 +158,12 @@
 					}
 				},
 				success: function(response){
+					var lastActive = parseInt(response.lastActive);
 					if($.trim(response.msg) !== options.serverResponseEquals){
 						self.failedRequests--;
 					} else {
-						if(self._is_int(response.lastActive) && response.lastActive > $(document).idleTimer('getTimes')['start']) {
-							$(document).idleTimer('handleUserEvent', response.lastActive);
+						if(self._is_int(lastActive) && lastActive > $(document).idleTimer('getTimes')['start']) {
+							$(document).idleTimer('handleUserEvent', lastActive);
 						}
 						options.onSuccess.call( undefined, response );
 					}

--- a/src/jquery.idletimeout.js
+++ b/src/jquery.idletimeout.js
@@ -63,6 +63,7 @@
 					else {
 						self.focused = true;
 					}
+					options.onFocusChange.call(self.focused, self.warning[0]);
 				});
 			}
 		},
@@ -149,6 +150,8 @@
 										  + '&page=' + encodeURIComponent(window.location.pathname),
 				dataType: "json",
 				error: function(xhr){
+					// Temporary comment for testing
+					console.log('keepalive error', self.failedRequests, xhr);
 					self.failedRequests--;
 					// Log out on a 401 status
 					if (xhr.status === 401) {
@@ -163,7 +166,9 @@
 						self.failedRequests--;
 					} else {
 						if(self._is_int(lastActive) && lastActive > $(document).idleTimer('getTimes')['start']) {
+							// Temporary comment for testing
 							$(document).idleTimer('handleUserEvent', lastActive);
+							console.log('keepalive success - start time should be updated', $(document).idleTimer('getTimes'), lastActive);
 						}
 						options.onSuccess.call( undefined, response );
 					}
@@ -267,7 +272,10 @@
 		onAbort: $.noop,
 
 		// An onSuccess callback for when the keepalive is successful.
-		onSuccess: $.noop
+		onSuccess: $.noop,
+
+		// callback for window focus changes
+		onFocusChange: $.noop
 	};
 
 })(jQuery, window);

--- a/src/jquery.idletimer.js
+++ b/src/jquery.idletimer.js
@@ -1,26 +1,26 @@
 /*
  * jQuery idleTimer plugin
  * version 0.8.092209
- * by Paul Irish. 
+ * by Paul Irish.
  *   http://github.com/paulirish/yui-misc/tree/
  * MIT license
- 
+
  * adapted from YUI idle timer by nzakas:
  *   http://github.com/nzakas/yui-misc/
- 
- 
+
+
  * Copyright (c) 2009 Nicholas C. Zakas
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,121 +28,141 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
+
+
+ * Major overhaul
+ * by Scott Connerly
+ * of Fire-Engine-Red.com
+ * 2015-09-21
+ *
  */
 
 (function($){
+    //http://stackoverflow.com/a/6871820/218967
+    var
+        sortaPublicMethods = {
+            init : function(options) {
+                /**
+                 * Starts the idle timer. This adds appropriate event handlers
+                 * and starts the first timeout.
+                 * @param {int} newTimeout (Optional) A new value for the timeout period in ms.
+                 * @return {void}
+                 * @method $.idleTimer
+                 * @static
+                 */
+                olddate = +new Date;
+                //assign a new timeout if requested
+                if (typeof options.newTimeout == "number"){
+                    timeout = options.newTimeout;
+                }
 
-$.idleTimer = function f(newTimeout){
+                //assign appropriate event handlers
+                $(document).bind($.trim((events+' ').split(' ').join('.idleTimer ')), function() {
+                    $(document).idleTimer('handleUserEvent');
+                });
 
-    //$.idleTimer.tId = -1     //timeout ID
+                //set a timeout to toggle state
+                $(document).idleTimer('setTimerId', setTimeout(toggleIdleState, timeout));
 
-    var idle    = false,        //indicates if the user is idle
+                // assume the user is active for the first x seconds.
+                $.data(document,'idleTimer',"active");
+            },
+            handleUserEvent : function( newOldDate ) {
+                /* Handles a user event indicating that the user isn't idle.
+                 * Moved this to be public so we could trigger "events" from other tabs (by way of the server session)
+                 * newOldDate is optional
+                 */
+
+                //clear any existing timeout
+                clearTimeout($(document).idleTimer('getTimerId'));
+                $(document).idleTimer('setTimerId',null);
+
+                //if the idle timer is enabled
+                if (enabled) {
+                    //if it's idle, that means the user is no longer idle
+                    if (idle) {
+                        toggleIdleState(newOldDate);
+                    }
+                    //set a new timeout
+                    $(document).idleTimer('setTimerId', setTimeout(toggleIdleState, timeout, newOldDate));
+                }
+            },
+            getTimes : function() {
+                var now = (+new Date);
+                return {
+                    start: olddate,
+                    now: now,
+                    elapsed: now - olddate
+                }
+            },
+            setTimerId : function(newTimerId) {
+                tId = newTimerId;
+            },
+            getTimerId : function() {
+                return tId;
+            }
+        },
+
+        idle    = false,        //indicates if the user is idle
         enabled = true,        //indicates if the idle timer is enabled
         timeout = 30000,        //the amount of time (ms) before the user is considered idle
         events  = 'mousemove keydown DOMMouseScroll mousewheel mousedown', // activity is one of these events
-      //f.olddate = undefined, // olddate used for getElapsedTime. stored on the function
-        
-    /* (intentionally not documented)
+        tId     = null,
+        olddate = null,
+    /*
      * Toggles the idle state and fires an appropriate event.
      * @return {void}
+     * private
      */
-    toggleIdleState = function(){
-    
-        //toggle the state
-        idle = !idle;
-        
-        // reset timeout counter
-        f.olddate = +new Date;
-        
-        //fire appropriate event
-        $(document).trigger(  $.data(document,'idleTimer', idle ? "idle" : "active" )  + '.idleTimer');            
-    },
+        toggleIdleState = function(newOldDate){
 
-    /**
-     * Stops the idle timer. This removes appropriate event handlers
-     * and cancels any pending timeouts.
-     * @return {void}
-     * @method stop
-     * @static
-     */         
-    stop = function(){
-    
-        //set to disabled
-        enabled = false;
-        
-        //clear any pending timeouts
-        clearTimeout($.idleTimer.tId);
-        
-        //detach the event handlers
-        $(document).unbind('.idleTimer');
-    },
-    
-    
-    /* (intentionally not documented)
-     * Handles a user event indicating that the user isn't idle.
-     * @param {Event} event A DOM2-normalized event object.
-     * @return {void}
-     */
-    handleUserEvent = function(){
-    
-        //clear any existing timeout
-        clearTimeout($.idleTimer.tId);
-        
-        
-        
-        //if the idle timer is enabled
-        if (enabled){
-        
-          
-            //if it's idle, that means the user is no longer idle
-            if (idle){
-                toggleIdleState();           
-            } 
-        
-            //set a new timeout
-            $.idleTimer.tId = setTimeout(toggleIdleState, timeout);
-            
-        }    
-     };
-    
-      
-    /**
-     * Starts the idle timer. This adds appropriate event handlers
-     * and starts the first timeout.
-     * @param {int} newTimeout (Optional) A new value for the timeout period in ms.
-     * @return {void}
-     * @method $.idleTimer
-     * @static
-     */ 
-    
-    
-    f.olddate = f.olddate || +new Date;
-    
-    //assign a new timeout if necessary
-    if (typeof newTimeout == "number"){
-        timeout = newTimeout;
-    } else if (newTimeout === 'destroy') {
-        stop();
-        return this;  
-    } else if (newTimeout === 'getElapsedTime'){
-        return (+new Date) - f.olddate;
-    }
-    
-    //assign appropriate event handlers
-    $(document).bind($.trim((events+' ').split(' ').join('.idleTimer ')),handleUserEvent);
-    
-    
-    //set a timeout to toggle state
-    $.idleTimer.tId = setTimeout(toggleIdleState, timeout);
-    
-    // assume the user is active for the first x seconds.
-    $.data(document,'idleTimer',"active");
-      
-    
+            //toggle the state
+            idle = !idle;
 
-    
-}; // end of $.idleTimer()
+            // reset timeout counter
+            if(typeof newOldDate != 'undefined') { //meaning it was passed in, probably from another tab.
+                olddate = newOldDate;
+            }
+            else {
+                olddate = +new Date;
+            }
 
-    
+            //fire appropriate event
+            $(document).trigger(  $.data(document,'idleTimer', idle ? "idle" : "active" )  + '.idleTimer');
+        },
 
+        /**
+         * Stops the idle timer. This removes appropriate event handlers
+         * and cancels any pending timeouts.
+         * @return {void}
+         * @method stop
+         * @static
+         * private
+         */
+        stop = function(){
+
+            //set to disabled
+            enabled = false;
+
+            //clear any pending timeouts
+            clearTimeout($(document).idleTimer('getTimerId'));
+            $(document).idleTimer('setTimerId',null);
+
+            //detach the event handlers
+            $(document).unbind('.idleTimer');
+        };
+
+    //The only really public method
+    $.fn.idleTimer = function(methodOrOptions) {
+        if ( sortaPublicMethods[methodOrOptions] ) {
+            return sortaPublicMethods[ methodOrOptions ].apply( this, Array.prototype.slice.call( arguments, 1 ));
+        } else if ( typeof methodOrOptions === 'object' || ! methodOrOptions ) {
+            // Default to "init"
+            return sortaPublicMethods.init.apply( this, arguments );
+        } else {
+            $.error( 'Method ' +  methodOrOptions + ' does not exist on jQuery.idleTimer' );
+        }
+    };
+
+    // end of $.idleTimer()
 })(jQuery);

--- a/src/jquery.idletimer.js
+++ b/src/jquery.idletimer.js
@@ -37,7 +37,7 @@
  *
  */
 
-(function($){
+module.exports = (function($){
     //http://stackoverflow.com/a/6871820/218967
     var
         sortaPublicMethods = {

--- a/src/jquery.idletimer.js
+++ b/src/jquery.idletimer.js
@@ -72,10 +72,17 @@
                  * Moved this to be public so we could trigger "events" from other tabs (by way of the server session)
                  * newOldDate is optional
                  */
-
                 //clear any existing timeout
                 clearTimeout($(document).idleTimer('getTimerId'));
                 $(document).idleTimer('setTimerId',null);
+
+                // Reset timeout counter
+                if (newOldDate !== undefined) { //meaning it was passed in, probably from another tab.
+                    olddate = newOldDate;
+                }
+                else {
+                    olddate = +new Date;
+                }
 
                 //if the idle timer is enabled
                 if (enabled) {

--- a/src/jquery.idletimer.js
+++ b/src/jquery.idletimer.js
@@ -91,7 +91,8 @@ module.exports = (function($){
                         toggleIdleState(newOldDate);
                     }
                     //set a new timeout
-                    $(document).idleTimer('setTimerId', setTimeout(toggleIdleState, timeout, newOldDate));
+                    var msTillTimeout = Math.max(timeout - (new Date - olddate), 0);
+                    $(document).idleTimer('setTimerId', setTimeout(toggleIdleState, msTillTimeout, newOldDate));
                 }
             },
             getTimes : function() {


### PR DESCRIPTION
When tab synch supplies newOldDate the timeout is incorrectly set to the full timeout instead of the remaining time based on the new timeout 